### PR TITLE
delegated auth -  add basic subjectaccessreivew map

### DIFF
--- a/stable/management-ingress/templates/management-ingress-deployment.yaml
+++ b/stable/management-ingress/templates/management-ingress-deployment.yaml
@@ -71,7 +71,7 @@ spec:
           - --pass-user-bearer-token=true
           - --pass-access-token=true
           - --scope=user:full
-          - --openshift-delegate-urls={"/":{}}
+          - '-openshift-delegate-urls={"/": {"resource": "projects", "verb": "list"}}'
           - --skip-provider-button=true
           - --cookie-secure=true
           - --cookie-expire=12h0m0s


### PR DESCRIPTION
this is to fix the non-admin user issue.  This fix is patched  here  https://console-openshift-console.apps.chocolate.dev08.red-chesterfield.com.

For bearer token Auth,  the oauth-proxy  along with  token validation  also does authorization check (SAR)   based on  the { path, resources access}  map specified in the delegated-url argument.

I was initially passing an empty json to this arg, to indicate no authorization checks. While this worked for cluster-admin users..  oauth-proxy wasnt accepting empty checks for non-admin users.

So I added a basic check,   "list"  access on /projects,    this is a  basic role any authenticated user has.. so any user to pass check as long as the token is valid.

https://github.com/open-cluster-management/backlog/issues/1107