### PR TITLE
Add readiness for oauth-proxy sidecar

### DIFF
--- a/stable/management-ingress/templates/management-ingress-deployment.yaml
+++ b/stable/management-ingress/templates/management-ingress-deployment.yaml
@@ -91,6 +91,15 @@ spec:
           - containerPort: {{ .Values.oauth_proxy.httpsPort }}
             name: public
             protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /oauth/healthz
+              port: {{ .Values.oauth_proxy.httpsPort }}
+              scheme: HTTPS
+            timeoutSeconds: 1
+            periodSeconds: 10
+            successThreshold: 1
+            failureThreshold: 3
           resources: {}
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File


### PR DESCRIPTION
fixed: https://github.com/open-cluster-management/backlog/issues/1706