### PR TITLE
add extra entries to deployment to help with custom ocp cert updates

### DIFF
--- a/stable/management-ingress/templates/management-ingress-deployment.yaml
+++ b/stable/management-ingress/templates/management-ingress-deployment.yaml
@@ -80,6 +80,8 @@ spec:
           - --tls-cert=/etc/tls/private/tls.crt
           - --tls-key=/etc/tls/private/tls.key
           - --cookie-secret=AAECAwQFBgcICQoLDA0OFw==
+          - --openshift-ca=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+          - --openshift-ca=/etc/tls/ocp/tls.crt
           image: "{{ .Values.global.imageOverrides.oauth_proxy }}"
           imagePullPolicy: {{ .Values.global.pullPolicy }}
           name: oauth-proxy
@@ -104,6 +106,8 @@ spec:
             name: tls-secret
           - mountPath: /etc/tls/ca
             name: ca-tls-secret
+          - mountPath: /etc/tls/ocp
+            name: ocp-tls-secret
         - env:
             - name: ENABLE_IMPERSONATION
               value: "{{ .Values.enable_impersonation }}"
@@ -192,6 +196,10 @@ spec:
             defaultMode: 420
             secretName: {{ .Release.Name }}-tls-secret
         - name: ca-tls-secret
+          secret:
+            defaultMode: 420
+            secretName: {{ .Values.cert.ca }}
+        - name: ocp-tls-secret
           secret:
             defaultMode: 420
             secretName: {{ .Values.cert.ca }}


### PR DESCRIPTION
This is to help address issue https://github.com/open-cluster-management/backlog/issues/2414.
We can likely do some more advanced updates in the future, for now this update will allow the user use the OCP customized ingress certificate by just updating 2 fields in the deployment:

1. Deployment volume named `tls-secret`: Update the secret name to `byo-ingress-tls-secret` - the secret containing the customized OCP certificate (the user has to create that secret).
2. Deployment volume named `ocp-tls-secret`: Update the secret name to `ocp-byo-ca` - the secret containing the CA certificate for the above certificate. (the user has to create this secret too).