### PR TITLE
undo ca fix to figure out why canary tests fail with that change

### DIFF
--- a/stable/management-ingress/templates/management-ingress-deployment.yaml
+++ b/stable/management-ingress/templates/management-ingress-deployment.yaml
@@ -80,8 +80,6 @@ spec:
           - --tls-cert=/etc/tls/private/tls.crt
           - --tls-key=/etc/tls/private/tls.key
           - --cookie-secret=AAECAwQFBgcICQoLDA0OFw==
-          - --openshift-ca=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-          - --openshift-ca=/etc/tls/ocp/tls.crt
           image: "{{ .Values.global.imageOverrides.oauth_proxy }}"
           imagePullPolicy: {{ .Values.global.pullPolicy }}
           name: oauth-proxy
@@ -106,8 +104,6 @@ spec:
             name: tls-secret
           - mountPath: /etc/tls/ca
             name: ca-tls-secret
-          - mountPath: /etc/tls/ocp
-            name: ocp-tls-secret
         - env:
             - name: ENABLE_IMPERSONATION
               value: "{{ .Values.enable_impersonation }}"
@@ -196,10 +192,6 @@ spec:
             defaultMode: 420
             secretName: {{ .Release.Name }}-tls-secret
         - name: ca-tls-secret
-          secret:
-            defaultMode: 420
-            secretName: {{ .Values.cert.ca }}
-        - name: ocp-tls-secret
           secret:
             defaultMode: 420
             secretName: {{ .Values.cert.ca }}


### PR DESCRIPTION
The canaries are failing due to a management ingress issue.  @TheRealHaoLiu and @gurnben figured out that the changes I am undoing here were causing a problem.  The canary builds use a let's encrypt trusted certificate in OCP.  I suspect they just needed to configure the ingress to trust that CA -- but not sure why things worked ok without my changes.  It's likely adding the `openshift-ca` limits the trust to only the specified CAs so no system(public) CAs are trusted.

Gurney gave me instructions to setup a cluster similar to canary clusters so I can do more testing with his setup.  For now we can undo this change.