### PR TITLE
Merge pull request #42 from open-cluster-management/undo-cert-ca-fix

### DIFF
--- a/stable/management-ingress/templates/management-ingress-deployment.yaml
+++ b/stable/management-ingress/templates/management-ingress-deployment.yaml
@@ -80,8 +80,6 @@ spec:
           - --tls-cert=/etc/tls/private/tls.crt
           - --tls-key=/etc/tls/private/tls.key
           - --cookie-secret=AAECAwQFBgcICQoLDA0OFw==
-          - --openshift-ca=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-          - --openshift-ca=/etc/tls/ocp/tls.crt
           image: "{{ .Values.global.imageOverrides.oauth_proxy }}"
           imagePullPolicy: {{ .Values.global.pullPolicy }}
           name: oauth-proxy
@@ -106,8 +104,6 @@ spec:
             name: tls-secret
           - mountPath: /etc/tls/ca
             name: ca-tls-secret
-          - mountPath: /etc/tls/ocp
-            name: ocp-tls-secret
         - env:
             - name: ENABLE_IMPERSONATION
               value: "{{ .Values.enable_impersonation }}"
@@ -196,10 +192,6 @@ spec:
             defaultMode: 420
             secretName: {{ .Release.Name }}-tls-secret
         - name: ca-tls-secret
-          secret:
-            defaultMode: 420
-            secretName: {{ .Values.cert.ca }}
-        - name: ocp-tls-secret
           secret:
             defaultMode: 420
             secretName: {{ .Values.cert.ca }}


### PR DESCRIPTION
undo ca fix to figure out why canary tests fail with that change