### PR TITLE
add the system certs to the CA list in addition to OCP and custom CA

### DIFF
--- a/stable/management-ingress/templates/management-ingress-deployment.yaml
+++ b/stable/management-ingress/templates/management-ingress-deployment.yaml
@@ -80,6 +80,9 @@ spec:
           - --tls-cert=/etc/tls/private/tls.crt
           - --tls-key=/etc/tls/private/tls.key
           - --cookie-secret=AAECAwQFBgcICQoLDA0OFw==
+          - --openshift-ca=/etc/pki/tls/cert.pem
+          - --openshift-ca=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+          - --openshift-ca=/etc/tls/ocp/tls.crt
           image: "{{ .Values.global.imageOverrides.oauth_proxy }}"
           imagePullPolicy: {{ .Values.global.pullPolicy }}
           name: oauth-proxy
@@ -104,6 +107,8 @@ spec:
             name: tls-secret
           - mountPath: /etc/tls/ca
             name: ca-tls-secret
+          - mountPath: /etc/tls/ocp
+            name: ocp-tls-secret
         - env:
             - name: ENABLE_IMPERSONATION
               value: "{{ .Values.enable_impersonation }}"
@@ -192,6 +197,10 @@ spec:
             defaultMode: 420
             secretName: {{ .Release.Name }}-tls-secret
         - name: ca-tls-secret
+          secret:
+            defaultMode: 420
+            secretName: {{ .Values.cert.ca }}
+        - name: ocp-tls-secret
           secret:
             defaultMode: 420
             secretName: {{ .Values.cert.ca }}


### PR DESCRIPTION
The previous changes for this did not include the entry
```
- --openshift-ca=/etc/pki/tls/cert.pem
```
The canaries use a trusted certificate so they work without the changes here, when the CA is customized we need to make sure the system CA certs and the customer brought CA are available to the oauth-proxy.  