### PR TITLE
try byo cert customizations to handle other byo scenarios

### DIFF
--- a/stable/management-ingress/templates/management-ingress-deployment.yaml
+++ b/stable/management-ingress/templates/management-ingress-deployment.yaml
@@ -174,7 +174,11 @@ spec:
             - /run.sh
             {{- end }}
             - /management-ingress
+            {{ if (lookup "v1" "Secret" .Release.Namespace "byo-ingress-tls-secret") }}
+            - --default-ssl-certificate=$(POD_NAMESPACE)/byo-ingress-tls-secret
+            {{ else }}
             - --default-ssl-certificate=$(POD_NAMESPACE)/{{ .Release.Name }}-tls-secret
+            {{ end }}
             - --configmap=$(POD_NAMESPACE)/{{ .Release.Name }}
             - --http-port={{ .Values.httpPort }}
             - --https-port={{ .Values.httpsPort }}


### PR DESCRIPTION
This is the custom ACM cert scenario.  We're really just trying to prevent upgrade from overwriting ACM specific customizations here.  This is not intended to change existing behavior related to OCP CA certs.

Note that the hard coded secret names will match values from the documentation: https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/1.0/html/security/security#certificates-2