### PR TITLE
Fix Canary test failed

### DIFF
--- a/stable/management-ingress/templates/management-ingress-deployment.yaml
+++ b/stable/management-ingress/templates/management-ingress-deployment.yaml
@@ -36,7 +36,6 @@ spec:
   template:
     metadata:
       annotations:
-        seccomp.security.alpha.kubernetes.io/pod: docker/default
         productID: "{{ .Chart.Name }}_{{ .Chart.Version }}_00000"
         productName: "{{ .Chart.Name }}"
         productVersion: "{{ .Chart.Version }}"

--- a/stable/management-ingress/templates/management-ingress-role.yaml
+++ b/stable/management-ingress/templates/management-ingress-role.yaml
@@ -21,14 +21,6 @@ rules:
   verbs:
   - get
 - apiGroups:
-  - security.openshift.io
-  resources:
-  - securitycontextconstraints
-  verbs:
-  - create
-  - list
-  - use
-- apiGroups:
   - certmanager.k8s.io
   resources:
   - clusterissuers


### PR DESCRIPTION
we make changes to enable management-ingress can be able to run as non-root. but there are some roles and security still request `privileged` permission so that the pod cannot be startup successfully - https://github.com/open-cluster-management/backlog/issues/3639

remove the unnecessary permission to ensure the pod can pick up `restricted` scc to automatically give the `runAsUser`.