### PR TITLE
remove runAsNonRoot for management-ingress

### DIFF
--- a/stable/management-ingress/templates/management-ingress-deployment.yaml
+++ b/stable/management-ingress/templates/management-ingress-deployment.yaml
@@ -145,7 +145,6 @@ spec:
           image: "{{ .Values.global.imageOverrides.management_ingress }}"
           securityContext:
             allowPrivilegeEscalation: true
-            runAsNonRoot: true
           ports:
             {{- if .Values.enable_impersonation }}
             - containerPort: {{ .Values.apiserver_secure_port }}


### PR DESCRIPTION
confirmed that the image upstream is currently running as root 
```
➜  console-api git:(master) docker run -it --entrypoint=sh  quay.io/open-cluster-management/management-ingress:2.0.0-SNAPSHOT-2020-07-22-14-43-47
sh-4.2# whoami
root
```
having image running as root with deployment runAsNonRoot causes ContainerCreationError