### PR TITLE
Fix helm version condition

### DIFF
--- a/stable/management-ingress/Chart.yaml
+++ b/stable/management-ingress/Chart.yaml
@@ -12,5 +12,5 @@ keywords:
 apiVersion: v1
 version: 3.4.0
 tillerVersion: ">=2.12.3"
-kubeVersion: ">=1.11.0"
+kubeVersion: ">=1.11.0-0"
 appVersion: "3.4.0"


### PR DESCRIPTION
add -0 to support pre-release kube version

open-cluster-management/backlog#4284