### PR TITLE
Remove runAsNonRoot: true for oauth-proxy

### DIFF
--- a/stable/management-ingress/templates/management-ingress-deployment.yaml
+++ b/stable/management-ingress/templates/management-ingress-deployment.yaml
@@ -103,7 +103,6 @@ spec:
           resources: {}
           securityContext:
             allowPrivilegeEscalation: true
-            runAsNonRoot: true
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
           volumeMounts:


### PR DESCRIPTION
Remove `runAsNonRoot: true` for oauth-proxy only, because the oauth-proxy image is run as anyuser. in some case, if scc is anyuid, the error throws `container has runAsNonRoot and image will run as root`

refer to: https://github.com/open-cluster-management/backlog/issues/4736
