### PR TITLE
Remove skip-provider-button flag

### DIFF
--- a/stable/management-ingress/templates/management-ingress-deployment.yaml
+++ b/stable/management-ingress/templates/management-ingress-deployment.yaml
@@ -74,7 +74,6 @@ spec:
           - --pass-access-token=true
           - --scope=user:full
           - '-openshift-delegate-urls={"/": {"resource": "projects", "verb": "list"}}'
-          - --skip-provider-button=true
           - --cookie-secure=true
           - --cookie-expire=12h0m0s
           - --cookie-refresh=8h0m0s


### PR DESCRIPTION
ref: https://github.com/stolostron/backlog/issues/16412

refer to this document - https://docs.google.com/document/d/1hrzblx89Ya2TGycTbATN6b2Hh0ORtn_eJVkBH-Lns64/edit#

Reviewed this solution in release meeting, we agreed to remove `skip-provider-button=true` flag to have an extra login page before going to standard OpenShift login page
<img width="605" alt="image" src="https://user-images.githubusercontent.com/7711311/162752255-7d804ae5-06e2-4606-863b-ba22123c7112.png">

The change requires UI e2e tests to make change to click this button to login.

Signed-off-by: clyang82 <chuyang@redhat.com>